### PR TITLE
[FIX] RCE using execFile()

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function gulpTape (options) {
       args.unshift(nycBinaryFilePath)
     }
 
-    const tapeProcess = childProcess.exec(args.join(' '), function (error) {
+    const tapeProcess = childProcess.execFile(args[0], args.slice(1), function (error) {
       if (error) {
         callback(new PluginError(pluginName, error))
       }


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-gulp-tape

### ⚙️ Description *

The `gulp-tape` module was vulnerable against `RCE` cause some `user inputs` where concatenated insecurely to a command which was then executed, leading to `arbitrary command injection`

### 💻 Technical Description *

I replaced `exec()` with `execFile()` to prevent the `arguments` could corrupt the `command` and `inject arbitrary code`

### 🐛 Proof of Concept (PoC) *

1. Create the PoC:

```js
// poc.js
var root = require("gulp-tape");
var gulp = require("gulp");
var options = {
  name: "& touch JHU.txt"
}
gulp.src("./gulp-tape.js")
  .pipe(root(options));
```
2. `node poc.js`
3. The `JHU` file is created

### 🔥 Proof of Fix (PoF) *

Same steps above with fixed version doesn't create the file

### 👍 User Acceptance Testing (UAT)

Just replaced `exec()` with `execFile()` 👍 