### PR TITLE
Fixed Command injection on Gulp-tape

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function gulpTape (options) {
     }
 
     var cmd = args.join(' ').split(' ');
-    const tapeProcess = childProcess.execFile(cmd[0], cmd.shift(), function (error) {
+    const tapeProcess = childProcess.execFile(cmd[0], cmd.slice(1), function (error) {
       if (error) {
         callback(new PluginError(pluginName, error))
       }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ function gulpTape (options) {
       args.unshift(nycBinaryFilePath)
     }
 
-    const tapeProcess = childProcess.exec(args.join(' '), function (error) {
+    var cmd = args.join(' ').split(' ');
+    const tapeProcess = childProcess.execFile(cmd[0], cmd.shift(), function (error) {
       if (error) {
         callback(new PluginError(pluginName, error))
       }


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-gulp-tape

### ⚙️ Description *

gulp-tape is a to run Tape tests in Gulp, this package are vulnerable to Command Injection. It is possible to inject arbitrary commands as part of gulp-tape options.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```javascript
var root = require("gulp-tape");
var gulp = require("gulp");
var options = {
  name: "& touch JHU.txt"
}
gulp.src("./gulp-tape.js")
  .pipe(root(options));
```

### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92396142-263eb200-f142-11ea-8c3c-06a4ff6abf8f.png)


### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
